### PR TITLE
Added slot before title on product-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Unreleased
+
+### Feature
+
+- Added `slot` before the title on `product-header` component.
+
 ## 0.8.0
 
 ### Feature

--- a/src/components/inputs/code-input/readme.md
+++ b/src/components/inputs/code-input/readme.md
@@ -34,6 +34,7 @@
 | `inputChange` |                                    | `CustomEvent<CodeInputEvent<string>>`                    |
 | `inputFocus`  |                                    | `CustomEvent<CodeInputEvent<CodeInputCustomEventValue>>` |
 
+
 ## Methods
 
 ### `clear() => Promise<void>`

--- a/src/components/product-header/product-header.tsx
+++ b/src/components/product-header/product-header.tsx
@@ -46,6 +46,9 @@ export class ProductHeader {
     return (
       <Host>
         <header class={`text-title ${this.sticky && 'sticky'}`}>
+          <div class="before-text">
+            <slot name="before-text"></slot>
+          </div>
           <div
             class="title"
             style={{ cursor: this.titleCursorPointer && 'pointer' }}

--- a/src/components/product-header/product-header.tsx
+++ b/src/components/product-header/product-header.tsx
@@ -46,8 +46,8 @@ export class ProductHeader {
     return (
       <Host>
         <header class={`text-title ${this.sticky && 'sticky'}`}>
-          <div class="before-text">
-            <slot name="before-text"></slot>
+          <div class="before-title">
+            <slot name="before-title"></slot>
           </div>
           <div
             class="title"

--- a/src/components/product-header/test/product-header.spec.tsx
+++ b/src/components/product-header/test/product-header.spec.tsx
@@ -11,6 +11,9 @@ describe('product-header', () => {
       <tec-product-header sticky="" theme="light">
         <mock:shadow-root>
           <header class="sticky text-title">
+          <div class="before-text">
+             <slot name="before-text"></slot>
+          </div>
             <div class="title" style="cursor: pointer"></div>
 
             <div class="content">
@@ -33,6 +36,9 @@ describe('product-header', () => {
       <tec-product-header sticky="false" title-product="My product" theme="light">
          <mock:shadow-root>
            <header class="false text-title">
+            <div class="before-text">
+              <slot name="before-text"></slot>
+            </div>
              <div class="title" style="cursor: pointer;">
                My product
              </div>
@@ -47,21 +53,21 @@ describe('product-header', () => {
 
   it('should emit event when titleCursorPointer is true', () => {
     const component = new ProductHeader();
-    const eventSpy = jest.spyOn(component.titleClicked, 'emit').mockImplementation()
+    const eventSpy = jest.spyOn(component.titleClicked, 'emit').mockImplementation();
     component.titleCursorPointer = true;
 
-    component.handleClick()
+    component.handleClick();
 
-    expect(eventSpy).toHaveBeenCalled()
-  })
+    expect(eventSpy).toHaveBeenCalled();
+  });
 
   it('should not emit event when titleCursorPointer is false', () => {
     const component = new ProductHeader();
-    const eventSpy = jest.spyOn(component.titleClicked, 'emit').mockImplementation()
+    const eventSpy = jest.spyOn(component.titleClicked, 'emit').mockImplementation();
     component.titleCursorPointer = false;
 
-    component.handleClick()
+    component.handleClick();
 
-    expect(eventSpy).not.toHaveBeenCalled()
-  })
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/product-header/test/product-header.spec.tsx
+++ b/src/components/product-header/test/product-header.spec.tsx
@@ -11,8 +11,8 @@ describe('product-header', () => {
       <tec-product-header sticky="" theme="light">
         <mock:shadow-root>
           <header class="sticky text-title">
-          <div class="before-text">
-             <slot name="before-text"></slot>
+          <div class="before-title">
+             <slot name="before-title"></slot>
           </div>
             <div class="title" style="cursor: pointer"></div>
 
@@ -36,8 +36,8 @@ describe('product-header', () => {
       <tec-product-header sticky="false" title-product="My product" theme="light">
          <mock:shadow-root>
            <header class="false text-title">
-            <div class="before-text">
-              <slot name="before-text"></slot>
+            <div class="before-title">
+              <slot name="before-title"></slot>
             </div>
              <div class="title" style="cursor: pointer;">
                My product

--- a/src/components/tec-modal/readme.md
+++ b/src/components/tec-modal/readme.md
@@ -12,7 +12,7 @@
 | `blockBodyScroll`   | `block-body-scroll`   |             | `boolean`                                                                           | `true`           |
 | `closeOnEscape`     | `close-on-escape`     |             | `boolean`                                                                           | `true`           |
 | `dismissOnBackdrop` | `dismiss-on-backdrop` |             | `boolean`                                                                           | `true`           |
-| `footerAlign`       | `footer-align`        |             | `TecAlign.center \| TecAlign.left \| TecAlign.none \| TecAlign.right`               | `TecAlign.right` |
+| `footerAlign`       | `footer-align`        |             | `TecAlign.center \| TecAlign.left \| TecAlign.right`                                | `TecAlign.right` |
 | `fullWidth`         | `full-width`          |             | `boolean`                                                                           | `false`          |
 | `modalTitle`        | `modal-title`         |             | `string`                                                                            | `undefined`      |
 | `opened`            | `opened`              |             | `boolean`                                                                           | `false`          |


### PR DESCRIPTION
* How to test?
Add some element with slot `before-text`, the element should be rendered before the product-header's title